### PR TITLE
Fix comment duplicates

### DIFF
--- a/src/components/organisms/Comments/index.jsx
+++ b/src/components/organisms/Comments/index.jsx
@@ -92,6 +92,28 @@ class Comments extends React.Component {
     }
   };
 
+  getChildren = (items, parentId) => {
+    let childComments = [];
+
+    // For each comment check if it belongs to the post and is a child comment
+    items.forEach((comment, i) => {
+      if (comment.data.cid && comment.data.cid === parentId) {
+        // Push child comment to array
+        childComments.push(
+          <Comment
+            comment={comment}
+            key={comment.id}
+            cid={comment.id}
+            refreshData={this.props.refreshData}
+            child
+          />
+        );
+      }
+    });
+
+    return childComments;
+  };
+
   render() {
     const { items } = this.props;
 
@@ -197,24 +219,10 @@ class Comments extends React.Component {
                             </div>
                           </>
                         )}
-                        {items.map((child) => {
-                          if (
-                            child.data.cid === comment.id &&
-                            child.data.visible
-                          ) {
-                            return (
-                              <Comment
-                                comment={child}
-                                key={
-                                  this.props.pid + comment.id + child.data.cid
-                                }
-                                cid={child.id}
-                                refreshData={this.props.refreshData}
-                                child
-                              />
-                            );
-                          } else return null;
-                        })}
+                        {this.getChildren(
+                          items.filter((c) => c.data.pid === this.props.pid),
+                          comment.id
+                        )}
                       </React.Fragment>
                     );
                   } else return null;


### PR DESCRIPTION
A bug has been fixed where child comments were duplicating on each load.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently child comments duplicate on each load. This can be traced back to nesting maps. #51 


**What is the new behavior (if this is a feature change)?**
- Child comments are now being gathered in a separate function which has fixed the issue. #51 


**Other information**:
- Ref.: https://stackoverflow.com/questions/55872724/react-is-mapping-duplicate-posts/55873137

