### PR TITLE
Fix join chat feature

### DIFF
--- a/src/components/organisms/Chat/index.jsx
+++ b/src/components/organisms/Chat/index.jsx
@@ -62,6 +62,15 @@ class Chat extends React.Component {
     );
   };
 
+  componentWillReceiveProps = (nextProps) => {
+    if (this.props.hasJoined === false && nextProps.hasJoined === true) {
+      this.props.getMessages(this.props.chatDetails.id);
+
+      // Scroll to bottom of chat
+      this.scrollToBottom();
+    }
+  };
+
   componentDidUpdate() {
     this.scrollToBottom();
   }


### PR DESCRIPTION
Fixed issue, where after joining chat, messages were not shown.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently after joining a country chat, the user cannot see the messages.


**What is the new behavior (if this is a feature change)?**
- The message handler is now being created after joining the chat

